### PR TITLE
fix: handle type prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "prettier": "^2.0.5",
-    "typescript": "^4.0.2"
+    "typescript": "^4.9.4"
   },
   "devDependencies": {
     "jest": "27.0.1"

--- a/src/parser.js
+++ b/src/parser.js
@@ -164,9 +164,11 @@ function parseImportDeclaration(code, sourceFile, importDeclaration) {
             name = element.propertyName.text;
           }
 
+          const elPrefixWithType = prefixWithType(element);
+
           imported.namedMembers.push({
-            name: fixMultipleUnderscore(name),
-            alias: fixMultipleUnderscore(alias),
+            name: elPrefixWithType(fixMultipleUnderscore(name)),
+            alias: elPrefixWithType(fixMultipleUnderscore(alias)),
           });
         }
       }
@@ -175,6 +177,10 @@ function parseImportDeclaration(code, sourceFile, importDeclaration) {
 
   return imported;
 }
+
+const prefixWithType = (element) => (name) => {
+  return element.isTypeOnly ? `type ${name}` : name;
+};
 
 // This hack circumvents a bug (?) in the TypeScript parser where a named
 // binding's name or alias that consists only of underscores contains an

--- a/test/sort-import.test.js
+++ b/test/sort-import.test.js
@@ -6,12 +6,14 @@ describe(`Custom sort import`, () => {
       const originalFileContent = `import b from "b-dep";
 import a from "a-dep";
 import {z, d} from "c-dep";
+import {type foo, baz, type bar} from "z-dep";
 `;
       const result = organizeImports(originalFileContent);
 
       expect(result).toEqual(`import a from "a-dep";
 import b from "b-dep";
 import {d, z} from "c-dep";
+import {baz, type bar, type foo} from "z-dep";
 `);
     });
 


### PR DESCRIPTION
Handle the `import {type thing, stuff} from "somewhere";` issue, though it should be noted that it'll take the `type` part into account when ordering the members meaning as per the test case that `type bar` will appear after `baz` (that code is in `import-sort`, so it's bothersome to alter).